### PR TITLE
Solve the problem of tproxy

### DIFF
--- a/scripts/lean.sh
+++ b/scripts/lean.sh
@@ -164,7 +164,10 @@ sed -i 's/192.168.1.1/192.168.2.1/g' package/base-files/files/bin/config_generat
 # Custom configs
 git am $GITHUB_WORKSPACE/patches/lean/*.patch
 echo -e " Lean's OpenWrt built on "$(date +%Y.%m.%d)"\n -----------------------------------------------------" >> package/base-files/files/etc/banner
-
+echo 'net.bridge.bridge-nf-call-iptables=0' >> package/base-files/files/etcsysctl.conf
+echo 'net.bridge.bridge-nf-call-ip6tables=0' >> package/base-files/files/etc/sysctl.conf
+echo 'net.bridge.bridge-nf-call-arptables=0' >> package/base-files/files/etc/sysctl.conf
+echo 'net.bridge.bridge-nf-filter-vlan-tagged=0' >> package/base-files/files/etc/sysctl.conf
 # Add CUPInfo
 pushd package/lean/autocore/files/arm/sbin
 cp -f $GITHUB_WORKSPACE/scripts/cpuinfo cpuinfo


### PR DESCRIPTION
Any protocol of tproxy from the lower-level router is unworkable, and so is tcp