### PR TITLE
fix: define MAX_TRANSMIT_POWER for mt_wifi7 rt_channel.c

### DIFF
--- a/immortalwrt/diy-mtk.sh
+++ b/immortalwrt/diy-mtk.sh
@@ -264,6 +264,20 @@ fi
 install -Dm0644 "$_mt_wifi7_declarations_patch_src" "$_mt_wifi7_declarations_patch_dst"
 echo "[DIY] mt_wifi7: GCC 14 missing declarations compatibility patch installed"
 
+# MTK mt_wifi7: rt_channel.c references MAX_TRANSMIT_POWER, which the
+# vendor source only defines locally in bcn.c. GCC 14 -Werror rejects the
+# undeclared identifier; provide the same constant in rt_channel.c.
+_mt_wifi7_max_tx_power_patch_src="$GITHUB_WORKSPACE/patches/filogic/25.12/1008-mt_wifi7-fix-max-transmit-power.patch"
+_mt_wifi7_max_tx_power_patch_dst="package/mtk/drivers/mt_wifi7/patches/016-fix-max-transmit-power.patch"
+
+if [ ! -f "$_mt_wifi7_max_tx_power_patch_src" ]; then
+    echo "Required mt_wifi7 compatibility patch not found: $_mt_wifi7_max_tx_power_patch_src" >&2
+    exit 1
+fi
+
+install -Dm0644 "$_mt_wifi7_max_tx_power_patch_src" "$_mt_wifi7_max_tx_power_patch_dst"
+echo "[DIY] mt_wifi7: MAX_TRANSMIT_POWER declaration compatibility patch installed"
+
 # datconf: disable parallel build (5 sub-packages share one CMake tree, race with -j>1)
 if [ -f "package/mtk/applications/datconf/Makefile" ] && \
    ! grep -q 'PKG_BUILD_PARALLEL' "package/mtk/applications/datconf/Makefile"; then

--- a/patches/filogic/25.12/1008-mt_wifi7-fix-max-transmit-power.patch
+++ b/patches/filogic/25.12/1008-mt_wifi7-fix-max-transmit-power.patch
@@ -1,0 +1,26 @@
+From: MedyMa <75345465+MedyMa@users.noreply.github.com>
+Subject: [PATCH] mt_wifi7: define MAX_TRANSMIT_POWER for rt_channel.c
+
+BuildCountryIEChList in rt_channel.c assigns MaxTxPower =
+MAX_TRANSMIT_POWER, but the vendor source only defines that macro
+locally in bcn.c. Under the driver's -Werror policy, GCC 14 rejects the
+undeclared identifier and package/mtk/drivers/mt_wifi7 fails to build.
+
+Provide the same 30 dBm constant (matching bcn.c) behind an #ifndef
+guard so rt_channel.c compiles without changing runtime behavior.
+
+diff --git a/mt_wifi/common/rt_channel.c b/mt_wifi/common/rt_channel.c
+index 072444e..15c2e21 100644
+--- a/mt_wifi/common/rt_channel.c
++++ b/mt_wifi/common/rt_channel.c
+@@ -8,6 +8,10 @@
+ #include "hdev/hdev_basic.h"
+ #endif
+ 
++#ifndef MAX_TRANSMIT_POWER
++#define MAX_TRANSMIT_POWER 30
++#endif
++
+ CH_DESC Country_Region0_ChDesc_2GHZ[] = {
+ 	{1, 11, 2402, 2472, CHANNEL_DEFAULT_PROP},
+ 	{}


### PR DESCRIPTION
rt_channel.c uses MAX_TRANSMIT_POWER but the vendor source only defines it locally in bcn.c, so GCC 14 -Werror fails the build with an undeclared-identifier error.

Add the same 30 dBm constant behind an #ifndef guard and install the patch as mt_wifi7 patches/016 in diy-mtk.sh.